### PR TITLE
Fix parameter name in utils

### DIFF
--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -19,10 +19,10 @@ export function encodedRedirect(
 // FROM ME:
 
 export const getAddCarButtonLabel = (
-  loaadingState: "idle" | "adding-car" | "posting-fb" | "saving-fb-data",
+  loadingState: "idle" | "adding-car" | "posting-fb" | "saving-fb-data",
   postOnFb: boolean,
 ) => {
-  switch (loaadingState) {
+  switch (loadingState) {
     case "adding-car":
       return "Se adaugă anunțul...";
     case "posting-fb":
@@ -35,8 +35,8 @@ export const getAddCarButtonLabel = (
   }
 };
 
-export const getModifyCarButtonLabel = (loaadingState: ModifyLoadingState) => {
-  switch (loaadingState) {
+export const getModifyCarButtonLabel = (loadingState: ModifyLoadingState) => {
+  switch (loadingState) {
     case "deleting-fb-post":
       return "Se șterge anunțul de pe Facebook...";
     case "deleting-record":


### PR DESCRIPTION
## Summary
- rename `loaadingState` parameter to `loadingState`
- adjust references inside utility functions

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683fdd1e81fc8325b489f22a8ccf05f5